### PR TITLE
Fix error in source generation when no FacetSearch attributes are present on the Faceted class

### DIFF
--- a/src/Facet.Search.Generators/Generators/MetadataGenerator.cs
+++ b/src/Facet.Search.Generators/Generators/MetadataGenerator.cs
@@ -45,7 +45,7 @@ internal static class MetadataGenerator
         sb.AppendLine("/// </summary>");
         sb.AppendLine($"public static class {model.ClassName}SearchMetadata");
         sb.AppendLine("{");
-        sb.AppendLine($"    public static IReadOnlyList<{metadataClassName}> Facets {{ get; }} = new[]");
+        sb.AppendLine($"    public static IReadOnlyList<{metadataClassName}> Facets {{ get; }} = new {metadataClassName}[]");
         sb.AppendLine("    {");
 
         foreach (var facet in model.Facets)


### PR DESCRIPTION
This PR solves the issue in https://github.com/Tim-Maes/Facet.Search/issues/39, where if you'd compile a class with `FacetedSearch` as an attribute, but without any properties that had a `FacetSearch` attribute on them, it'd result in an error. The generated file would have a property called `Facets` with an array where .NET can't infer the element type.

This PR solves this issue by setting the `metadataClassName` explicitly as the element type of the generated property `Facets`.