### PR TITLE
Support arrays

### DIFF
--- a/src/Facet.Search.Generators/Generators/AggregationGenerator.cs
+++ b/src/Facet.Search.Generators/Generators/AggregationGenerator.cs
@@ -74,7 +74,24 @@ internal static class AggregationGenerator
             {
                 bool isNullable = facet.PropertyType.EndsWith("?") || facet.PropertyType == "string";
                 sb.AppendLine($"        results.{facet.PropertyName} = query");
-                if (isNullable)
+
+                if (facet.IsCollection)
+                {
+                    // For collection properties, flatten with SelectMany first
+                    sb.AppendLine($"            .SelectMany(x => x.{facet.PropertyName})");
+                    // Element type nullability check
+                    var elemIsNullable = facet.ElementType != null && (facet.ElementType.EndsWith("?") || facet.ElementType == "string");
+                    if (elemIsNullable)
+                    {
+                        sb.AppendLine("            .Where(e => e != null)");
+                        sb.AppendLine("            .GroupBy(e => e!)");
+                    }
+                    else
+                    {
+                        sb.AppendLine("            .GroupBy(e => e)");
+                    }
+                }
+                else if (isNullable)
                 {
                     sb.AppendLine($"            .Where(x => x.{facet.PropertyName} != null)");
                     sb.AppendLine($"            .GroupBy(x => x.{facet.PropertyName}!)");
@@ -92,7 +109,7 @@ internal static class AggregationGenerator
                     sb.AppendLine($"            .Take({facet.Limit})");
                 }
 
-                if (IsStringPropertyType(facet.PropertyType))
+                if (facet.IsCollection ? IsStringPropertyType(facet.ElementType ?? "") : IsStringPropertyType(facet.PropertyType))
                     sb.AppendLine("            .ToDictionary(x => x.Value, x => x.Count);");
                 else
                     sb.AppendLine("            .ToDictionary(x => x.Value.ToString()!, x => x.Count);");

--- a/src/Facet.Search.Generators/Generators/ExtensionMethodsGenerator.cs
+++ b/src/Facet.Search.Generators/Generators/ExtensionMethodsGenerator.cs
@@ -288,7 +288,10 @@ internal static class ExtensionMethodsGenerator
             case "Categorical":
             case "Hierarchical":
                 sb.AppendLine($"        if (filter.{facet.PropertyName}?.Any() == true)");
-                sb.AppendLine($"            query = query.Where(x => filter.{facet.PropertyName}.Contains(x.{accessPath}));");
+                if (facet.IsCollection)
+                    sb.AppendLine($"            query = query.Where(x => x.{accessPath}.Any(e => filter.{facet.PropertyName}.Contains(e)));");
+                else
+                    sb.AppendLine($"            query = query.Where(x => filter.{facet.PropertyName}.Contains(x.{accessPath}));");
                 break;
             case "Range":
                 sb.AppendLine($"        if (filter.Min{facet.PropertyName}.HasValue)");
@@ -318,10 +321,10 @@ internal static class ExtensionMethodsGenerator
             .Select(p => p.Name)
             .ToList();
 
-        // All facet properties are also sortable
+        // All non-collection facet properties are also sortable
         foreach (var facet in model.Facets)
         {
-            if (!sortableProperties.Contains(facet.PropertyName))
+            if (!facet.IsCollection && !sortableProperties.Contains(facet.PropertyName))
                 sortableProperties.Add(facet.PropertyName);
         }
 

--- a/src/Facet.Search.Generators/Generators/FilterClassGenerator.cs
+++ b/src/Facet.Search.Generators/Generators/FilterClassGenerator.cs
@@ -83,7 +83,7 @@ internal static class FilterClassGenerator
                 break;
             case "Categorical":
             case "Hierarchical":
-                sb.AppendLine($"    public {GetCategoricalElementType(facet.PropertyType)}[]? {facet.PropertyName} {{ get; set; }}");
+                sb.AppendLine($"    public {GetCategoricalElementType(facet)}[]? {facet.PropertyName} {{ get; set; }}");
                 break;
             case "Boolean":
                 sb.AppendLine($"    public bool? {facet.PropertyName} {{ get; set; }}");
@@ -96,8 +96,15 @@ internal static class FilterClassGenerator
     }
 
     /// <summary>
-    /// Returns the base element type for a categorical filter array, stripping any nullable marker.
+    /// Returns the base element type for a categorical filter array.
+    /// For collection properties, returns the collection's element type.
+    /// For scalar properties, returns the property type with nullable marker stripped.
     /// </summary>
-    private static string GetCategoricalElementType(string propertyType) =>
-        propertyType.TrimEnd('?');
+    private static string GetCategoricalElementType(SearchFacetInfo facet)
+    {
+        if (facet.IsCollection && facet.ElementType != null)
+            return facet.ElementType.TrimEnd('?');
+
+        return facet.PropertyType.TrimEnd('?');
+    }
 }

--- a/src/Facet.Search.Generators/Models/SearchFacetInfo.cs
+++ b/src/Facet.Search.Generators/Models/SearchFacetInfo.cs
@@ -16,7 +16,9 @@ internal sealed record SearchFacetInfo(
     string RangeAggregation,
     string? RangeIntervals,
     string? NavigationPath,
-    bool AutoInclude
+    bool AutoInclude,
+    bool IsCollection,
+    string? ElementType
 ) : IEquatable<SearchFacetInfo>
 {
     /// <summary>
@@ -62,6 +64,28 @@ internal sealed record SearchFacetInfo(
         string? navigationPath = null;
         var autoInclude = true;
 
+        // Detect collection types
+        var isCollection = false;
+        string? elementType = null;
+        var typeSymbol = property.Type;
+
+        // Check for array types (string[])
+        if (typeSymbol is IArrayTypeSymbol arrayType)
+        {
+            isCollection = true;
+            elementType = arrayType.ElementType.ToDisplayString();
+        }
+        // Check for generic collection types (List<T>, IEnumerable<T>, ICollection<T>, etc.)
+        else if (typeSymbol is INamedTypeSymbol namedType)
+        {
+            var elementTypeSymbol = GetCollectionElementType(namedType);
+            if (elementTypeSymbol != null)
+            {
+                isCollection = true;
+                elementType = elementTypeSymbol.ToDisplayString();
+            }
+        }
+
         foreach (var namedArg in attribute.NamedArguments)
         {
             switch (namedArg.Key)
@@ -102,7 +126,36 @@ internal sealed record SearchFacetInfo(
         return new SearchFacetInfo(
             propertyName, propertyType, facetType, displayName, orderBy,
             limit, dependsOn, isHierarchical, rangeAggregation, rangeIntervals,
-            navigationPath, autoInclude);
+            navigationPath, autoInclude, isCollection, elementType);
+    }
+
+    /// <summary>
+    /// Extracts the element type from a generic collection type (List&lt;T&gt;, IEnumerable&lt;T&gt;, ICollection&lt;T&gt;, etc.)
+    /// Returns null if the type is not a recognized collection.
+    /// </summary>
+    private static ITypeSymbol? GetCollectionElementType(INamedTypeSymbol type)
+    {
+        // Check if the type itself implements IEnumerable<T>
+        if (type.OriginalDefinition.SpecialType == SpecialType.System_String)
+            return null; // string implements IEnumerable<char>, but we don't want to treat it as a collection
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (iface.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>"
+                && iface.TypeArguments.Length == 1)
+            {
+                return iface.TypeArguments[0];
+            }
+        }
+
+        // Also check if the type itself is IEnumerable<T>
+        if (type.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>"
+            && type.TypeArguments.Length == 1)
+        {
+            return type.TypeArguments[0];
+        }
+
+        return null;
     }
 
     private static string? GetEnumName(TypedConstant constant)

--- a/tests/Facet.Search.Tests/MetadataGeneratorTests.cs
+++ b/tests/Facet.Search.Tests/MetadataGeneratorTests.cs
@@ -13,8 +13,8 @@ public class MetadataGeneratorTests
         // Act
         var facets = TestProductSearchMetadata.Facets;
 
-        // Assert - Brand, Category, Price, InStock, CreatedAt = 5 facets
-        Assert.Equal(5, facets.Count);
+        // Assert - Brand, Category, Price, InStock, CreatedAt, Tags, Sizes = 7 facets
+        Assert.Equal(7, facets.Count);
     }
 
     [Fact]

--- a/tests/Facet.Search.Tests/Models/TestProduct.cs
+++ b/tests/Facet.Search.Tests/Models/TestProduct.cs
@@ -33,4 +33,10 @@ public class TestProduct
 
     [Searchable(Sortable = true)]
     public int Rating { get; set; }
+
+    [SearchFacet(Type = FacetType.Categorical, DisplayName = "Tags")]
+    public List<string> Tags { get; set; } = new();
+
+    [SearchFacet(Type = FacetType.Categorical, DisplayName = "Sizes")]
+    public string[] Sizes { get; set; } = Array.Empty<string>();
 }


### PR DESCRIPTION
Fixes and closes #32 

`[SearchFacet]` only worked on scalar properties. Using it on collection types (`List<string>`, `string[]`, `IEnumerable<T>`, etc.) produced broken generated code:

- Filter class generated `List<string>[]?` instead of `string[]?`
- Filter LINQ used `filter.Tags.Contains(x.Tags)` instead of checking if any element matches
- Aggregation used `GroupBy` directly on the collection instead of flattening first
- Sorting tried to `OrderBy` a collection property

## Changes

### `SearchFacetInfo.cs`
- Added `IsCollection` and `ElementType` fields
- `Create` detects arrays and generic `IEnumerable<T>` types (excluding `string`) and extracts the element type

### `FilterClassGenerator.cs`
- `GetCategoricalElementType` uses `ElementType` for collections, so `List<string>` produces `string[]?` not `List<string>[]?`

### `ExtensionMethodsGenerator.cs`
- Collection categorical filters generate `x.Tags.Any(e => filter.Tags.Contains(e))` instead of `filter.Tags.Contains(x.Tags)`
- Collection facets are excluded from auto-generated sort options

### `AggregationGenerator.cs`
- Collection facets use `SelectMany` to flatten before `GroupBy` for correct per-element counts

### Tests
- Added `List<string> Tags` and `string[] Sizes` to `TestProduct` test model
- Updated facet count assertion

## Usage

```csharp
[FacetedSearch]
public class Product
{
    [SearchFacet(Type = FacetType.Categorical)]
    public List<string> Tags { get; set; } = new();

    [SearchFacet(Type = FacetType.Categorical)]
    public string[] Sizes { get; set; } = Array.Empty<string>();

    [SearchFacet(NavigationPath = "Category.Name")]
    public string CategoryName { get; set; } = null!;
}
```